### PR TITLE
Added mango selector to changes feed

### DIFF
--- a/src/main/java/org/lightcouch/CouchDbClient.java
+++ b/src/main/java/org/lightcouch/CouchDbClient.java
@@ -229,7 +229,6 @@ public class CouchDbClient extends CouchDbClientBase implements Closeable {
 		HttpClientUtils.closeQuietly(this.httpClient);
 	}
 
-	@Override
 	public void close() throws IOException {
 		shutdown();
 	}

--- a/src/main/java/org/lightcouch/CouchDbClientBase.java
+++ b/src/main/java/org/lightcouch/CouchDbClientBase.java
@@ -622,6 +622,34 @@ public abstract class CouchDbClientBase {
 	}
 	
 	/**
+	 * Performs a HTTP POST request.
+	 *
+	 * @return {@link HttpResponse}
+	 */
+	InputStream post(HttpPost post, String json) {
+		setEntity(post, json);
+		HttpResponse resp = executeRequest(post);
+		return getStream(resp);
+	}
+	
+	/**
+	 * Performs a HTTP POST request.
+	 *
+	 * @return An object of type T
+	 */
+	<T> T post(URI uri, String json, Class<T> classType) {
+		InputStream in = null;
+		try {
+			in = getStream(post(uri, json));
+			return getGson().fromJson(new InputStreamReader(in, "UTF-8"), classType);
+		} catch (UnsupportedEncodingException e) {
+			throw new CouchDbException(e);
+		} finally {
+			close(in);
+		}
+	}
+	
+	/**
 	 * Performs a HTTP DELETE request.
 	 * @return {@link Response}
 	 */

--- a/src/test/java/org/lightcouch/tests/ChangeNotificationsTest.java
+++ b/src/test/java/org/lightcouch/tests/ChangeNotificationsTest.java
@@ -74,6 +74,28 @@ public class ChangeNotificationsTest {
 	}
 
 	@Test
+	public void changes_normalFeed_selector() {
+		dbClient.save(new Foo());
+
+		ChangesResult changes = dbClient.changes().includeDocs(true).limit(1)
+				.selector("{\"selector\":{\"_id\": {\"$gt\": null}}}").getChanges();
+
+		List<ChangesResult.Row> rows = changes.getResults();
+
+		for (Row row : rows) {
+			List<ChangesResult.Row.Rev> revs = row.getChanges();
+			String docId = row.getId();
+			JsonObject doc = row.getDoc();
+
+			assertNotNull(revs);
+			assertNotNull(docId);
+			assertNotNull(doc);
+		}
+
+		assertThat(rows.size(), is(1));
+	}
+	
+	@Test
 	public void changes_continuousFeed() {
 		dbClient.save(new Foo()); 
 
@@ -92,6 +114,31 @@ public class ChangeNotificationsTest {
 			ChangesResult.Row feed = changes.next();
 			final JsonObject feedObject = feed.getDoc();
 			final String docId = feed.getId();
+
+			assertEquals(response.getId(), docId);
+			assertNotNull(feedObject);
+
+			changes.stop();
+		}
+	}
+	
+	@Test
+	public void changes_continuousFeed_selector() {
+		dbClient.save(new Foo());
+
+		CouchDbInfo dbInfo = dbClient.context().info();
+		String since = dbInfo.getUpdateSeq();
+
+		Changes changes = dbClient.changes().includeDocs(true).since(since).heartBeat(1000)
+				.selector("{\"selector\":{\"_id\": {\"$gt\": null}}}").continuousChanges();
+
+		Response response = dbClient.save(new Foo());
+
+		while (changes.hasNext()) {
+			ChangesResult.Row feed = changes.next();
+			final JsonObject feedObject = feed.getDoc();
+			final String docId = feed.getId();
+			System.out.println("next()=" + docId);
 
 			assertEquals(response.getId(), docId);
 			assertNotNull(feedObject);


### PR DESCRIPTION
We are using selectors in the changes feed for performance improvement. We are using changes proposed from @orolle Pull Request: https://github.com/lightcouch/LightCouch/pull/63

I've cleaned up the previous pull request making a new mergeable pull request. 

Please, consider integrate it into the library as it provides a more performant usage of the changes feed filtering. 

It is a proposal for include the PR https://github.com/lightcouch/LightCouch/pull/65 in an active fork