### PR TITLE
Add explicit API for Local Document management

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # 0.2.2 (UNRELEASED)
+- [NEW] Added explicit API for local document management.
 
 # 0.2.1 (21/02/2018)
 - [NEW] Added API for specifying a mango selector _changes operation

--- a/src/main/java/org/lightcouch/CouchDbClientBase.java
+++ b/src/main/java/org/lightcouch/CouchDbClientBase.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2018 indaba.es
  * Copyright (C) 2011 lightcouch.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/lightcouch/CouchDbClientBase.java
+++ b/src/main/java/org/lightcouch/CouchDbClientBase.java
@@ -82,6 +82,7 @@ public abstract class CouchDbClientBase {
 	private Gson gson; 
 	private CouchDbContext context;
 	private CouchDbDesign design;
+	private Local local;
 	final HttpClient httpClient;
 	final HttpHost host;
 	
@@ -101,6 +102,7 @@ public abstract class CouchDbClientBase {
 		
 		this.context = new CouchDbContext(this, props); 
 		this.design = new CouchDbDesign(this);
+		this.local = new Local(this);
 	}
 	
 	// Client(s) provided implementation
@@ -145,6 +147,10 @@ public abstract class CouchDbClientBase {
 	 */
 	public View view(String viewId) {
 		return new View(this, viewId);
+	}
+	
+	public Local local() {
+	    return local;
 	}
 
 	/**

--- a/src/main/java/org/lightcouch/Local.java
+++ b/src/main/java/org/lightcouch/Local.java
@@ -114,9 +114,24 @@ public class Local {
         return remove(id);
     }
 
+    public Response removeWithRev(Object object) {
+        assertNotEmpty(object, "object");
+        JsonObject jsonObject = dbc.getGson().toJsonTree(object).getAsJsonObject();
+        final String id = getAsString(jsonObject, "_id");
+        final String rev = getAsString(jsonObject, "_rev");
+        return remove(id, rev);
+    }
+
     public Response remove(String id) {
         assertNotEmpty(id, "id");
         final URI docURI = buildURIforLocal(id);
+        return dbc.delete(docURI);
+    }
+
+    public Response remove(String id, String rev) {
+        assertNotEmpty(id, "id");
+        assertNotEmpty(id, "rev");
+        final URI docURI = buildUri(buildURIforLocal(id)).query("rev", rev).build();
         return dbc.delete(docURI);
     }
 

--- a/src/main/java/org/lightcouch/Local.java
+++ b/src/main/java/org/lightcouch/Local.java
@@ -1,0 +1,139 @@
+package org.lightcouch;
+
+import static org.lightcouch.CouchDbUtil.assertNotEmpty;
+import static org.lightcouch.CouchDbUtil.close;
+import static org.lightcouch.CouchDbUtil.getAsString;
+import static org.lightcouch.URIBuilder.buildUri;
+
+import java.net.URI;
+import java.util.List;
+
+import org.apache.http.HttpResponse;
+
+import com.google.gson.JsonObject;
+
+public class Local {
+
+    private static String LOCAL_PATH = "_local";
+
+    private CouchDbClientBase dbc;
+    private URI dbURI;
+    private View localDocsView;
+
+    Local(CouchDbClientBase dbc) {
+        this.dbc = dbc;
+        dbURI = buildUri(dbc.getDBUri()).path(LOCAL_PATH).path("/").build();
+        localDocsView = new View(dbc, "_local_docs");
+    }
+
+    public View localDocs() {
+        return localDocsView;
+    }
+
+    public List<JsonObject> findAll() {
+        return findAll(JsonObject.class);
+    }
+
+    public <T> List<T> findAll(Class<T> classType) {
+        assertNotEmpty(classType, "Class");
+        return (List<T>) localDocsView.includeDocs(true).query(classType);
+    }
+
+    /**
+     * Finds JSON Object.
+     * 
+     * @param id The document id.
+     * @return An JSON object.
+     * @throws NoDocumentException If the document is not found in the database.
+     */
+    public JsonObject find(String id) {
+        return find(JsonObject.class, id);
+    }
+
+    /**
+     * Finds an Object of the specified type.
+     * 
+     * @param <T> Object type.
+     * @param classType The class of type T.
+     * @param id The document id.
+     * @return An object of type T.
+     * @throws NoDocumentException If the document is not found in the database.
+     */
+    public <T> T find(Class<T> classType, String id) {
+        assertNotEmpty(classType, "Class");
+        assertNotEmpty(id, "id");
+        final URI uri = buildURIforLocal(id);
+        return dbc.get(uri, classType);
+    }
+
+    /**
+     * Checks if a document exist in the database.
+     * 
+     * @param id The document _id field.
+     * @return true If the document is found, false otherwise.
+     */
+    public boolean contains(String id) {
+        assertNotEmpty(id, "id");
+        HttpResponse response = null;
+        try {
+            final URI uri = buildURIforLocal(id);
+            response = dbc.head(uri);
+        } catch (NoDocumentException e) {
+            return false;
+        } finally {
+            close(response);
+        }
+        return true;
+    }
+
+    public Response save(Object object) {
+        return dbc.put(dbURI, object, true);
+    }
+
+    public Response update(Object object) {
+
+        final JsonObject json = dbc.getGson().toJsonTree(object).getAsJsonObject();
+        String id = CouchDbUtil.getAsString(json, "_id");
+        URI baseURI = buildURIforLocal(id, false);
+        return dbc.put(baseURI, object, false);
+    }
+
+    /**
+     * Removes a document from the database.
+     * <p>
+     * The object must have the correct <code>_id</code> and <code>_rev</code> values.
+     * 
+     * @param object The document to remove as object.
+     * @throws NoDocumentException If the document is not found in the database.
+     * @return {@link Response}
+     */
+    public Response remove(Object object) {
+        assertNotEmpty(object, "object");
+        JsonObject jsonObject = dbc.getGson().toJsonTree(object).getAsJsonObject();
+        final String id = getAsString(jsonObject, "_id");
+        return remove(id);
+    }
+
+    public Response remove(String id) {
+        assertNotEmpty(id, "id");
+        final URI docURI = buildURIforLocal(id);
+        return dbc.delete(docURI);
+    }
+
+    private URI buildURIforLocal(String id) {
+
+        return buildURIforLocal(id, true);
+    }
+
+    private URI buildURIforLocal(String id, boolean includeId) {
+        URI baseURI = dbURI;
+        if (id.startsWith(LOCAL_PATH)) {
+            baseURI = dbc.getDBUri();
+        }
+        if (includeId) {
+            return buildUri(baseURI).pathEncoded(id).build();
+        } else {
+            return buildUri(baseURI).build();
+        }
+    }
+}

--- a/src/main/java/org/lightcouch/Local.java
+++ b/src/main/java/org/lightcouch/Local.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2018 indaba.es
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.lightcouch;
 
 import static org.lightcouch.CouchDbUtil.assertNotEmpty;
@@ -14,7 +30,7 @@ import com.google.gson.JsonObject;
 
 public class Local {
 
-    private static String LOCAL_PATH = "_local";
+    private static final String LOCAL_PATH = "_local";
 
     private CouchDbClientBase dbc;
     private URI dbURI;

--- a/src/test/java/org/lightcouch/tests/CouchDbTestBase.java
+++ b/src/test/java/org/lightcouch/tests/CouchDbTestBase.java
@@ -26,4 +26,8 @@ public class CouchDbTestBase {
         return version.startsWith("2");
     }
     
+    protected boolean isCouchDB1() {
+        String version = dbClient.context().serverVersion();
+        return version.startsWith("0") || version.startsWith("1") ;
+    }
 }

--- a/src/test/java/org/lightcouch/tests/LocalDocumentsCRUDTest.java
+++ b/src/test/java/org/lightcouch/tests/LocalDocumentsCRUDTest.java
@@ -1,0 +1,194 @@
+package org.lightcouch.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.Test;
+import org.lightcouch.NoDocumentException;
+import org.lightcouch.Response;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+public class LocalDocumentsCRUDTest extends CouchDbTestBase {
+
+    @Test
+    public void findById() {
+        Response response = dbClient.local().save(new Foo("test"));
+        Foo foo = dbClient.local().find(Foo.class, response.getId());
+        assertNotNull(foo);
+        foo = dbClient.local().find(Foo.class, "test");
+        assertNotNull(foo);
+    }
+
+    @Test
+    public void findByIdContainSlash() {
+        String generatedId = generateUUID() + "/" + generateUUID();
+        Response response = dbClient.local().save(new Foo(generatedId));
+        Foo foo = dbClient.local().find(Foo.class, response.getId());
+        assertNotNull(foo);
+
+        Foo foo2 = dbClient.local().find(Foo.class, generatedId);
+        assertNotNull(foo2);
+    }
+
+    @Test
+    public void findJsonObject() {
+        Response response = dbClient.local().save(new Foo());
+        JsonObject jsonObject = dbClient.local().find(JsonObject.class, response.getId());
+        assertNotNull(jsonObject);
+
+        JsonObject jsonObject2 = dbClient.local().find(response.getId());
+        assertNotNull(jsonObject2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void findWithInvalidId_throwsIllegalArgumentException() {
+        dbClient.local().find(Foo.class, "");
+    }
+
+    @Test(expected = NoDocumentException.class)
+    public void findWithUnknownId_throwsNoDocumentException() {
+        dbClient.local().find(Foo.class, generateUUID());
+    }
+
+    @Test
+    public void contains() {
+        Response response = dbClient.local().save(new Foo());
+        boolean found = dbClient.local().contains(response.getId());
+        assertTrue(found);
+
+        found = dbClient.local().contains(generateUUID());
+        assertFalse(found);
+    }
+
+    // Save
+
+    @Test
+    public void savePOJO() {
+        Response response = dbClient.local().save(new Foo());
+        assertNotNull(response.getId());
+    }
+
+    @Test
+    public void saveMap() {
+
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put("_id", generateUUID());
+        map.put("field1", "value1");
+        Response response = dbClient.local().save(map);
+        assertNotNull(response.getId());
+    }
+
+    @Test
+    public void saveJsonObject() {
+        JsonObject json = new JsonObject();
+        json.addProperty("_id", generateUUID());
+        json.add("json-array", new JsonArray());
+        Response response = dbClient.local().save(json);
+        assertNotNull(response.getId());
+    }
+
+    @Test
+    public void saveWithIdContainSlash() {
+        String idWithSlash = "a/b/" + generateUUID();
+        Response response = dbClient.local().save(new Foo(idWithSlash));
+        assertEquals("_local/" + idWithSlash, response.getId());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void saveInvalidObject_throwsIllegalArgumentException() {
+        dbClient.save(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void saveNewDocWithRevision_throwsIllegalArgumentException() {
+        Bar bar = new Bar();
+        bar.setRevision("unkown");
+        dbClient.save(bar);
+    }
+
+    @Test
+    public void saveDocWithDuplicateId_allowed() {
+        String id = generateUUID();
+        dbClient.local().save(new Foo(id, "one"));
+        Foo foo = dbClient.local().find(Foo.class, id);
+        assertTrue("one".equals(foo.getTitle()));
+
+        dbClient.local().save(new Foo(id, "two"));
+        foo = dbClient.local().find(Foo.class, id);
+        assertTrue("two".equals(foo.getTitle()));
+    }
+
+ // Update
+
+    @Test
+    public void update() {
+        Response response = dbClient.local().save(new Foo());
+        Foo foo = dbClient.local().find(Foo.class, response.getId());
+        response = dbClient.local().update(foo);
+        assertNotNull(response.getId());
+    }
+    
+    @Test
+    public void updateWithIdContainSlash() {
+        String idWithSlash = "a/" + generateUUID();
+        Response response = dbClient.local().save(new Bar(idWithSlash));
+        
+        Bar bar = dbClient.local().find(Bar.class, response.getId());
+        Response responseUpdate = dbClient.local().update(bar);
+        assertEquals("_local/"+idWithSlash, responseUpdate.getId());
+    }
+
+    // Delete
+
+    @Test
+    public void deleteObject() {
+        Response response = dbClient.local().save(new Foo());
+        Foo foo = dbClient.local().find(Foo.class, response.getId());
+        dbClient.local().remove(foo);
+    }
+
+    @Test
+    public void deleteByIdAndRevValues() {
+        Response response = dbClient.local().save(new Foo());
+        response = dbClient.local().remove(response.getId());
+        assertNotNull(response);
+    }
+    
+    @Test
+    public void deleteByIdContainSlash() {
+        String idWithSlash = "a/" + generateUUID();
+        Response response = dbClient.local().save(new Bar(idWithSlash));
+        
+        Response responseRemove = dbClient.local().remove(response.getId());
+        assertEquals("_local/"+idWithSlash, responseRemove.getId());
+    }
+    
+    @Test
+    public void findAllLocalDocs() {
+
+        List<JsonObject> list =  dbClient.local().findAll();
+        int intialSize = list.size();
+        dbClient.local().save(new Foo("test1"));
+        dbClient.local().save(new Foo("test2"));
+        dbClient.save(new Foo("test3"));
+        
+        list =  dbClient.local().findAll();
+        assertTrue(list.size()==intialSize+2);
+    }
+
+
+    // Helper
+    private static String generateUUID() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+
+}

--- a/src/test/java/org/lightcouch/tests/ReplicationTest.java
+++ b/src/test/java/org/lightcouch/tests/ReplicationTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.lightcouch.URIBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.AfterClass;
@@ -34,12 +33,12 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.lightcouch.CouchDbClient;
-import org.lightcouch.CouchDbException;
 import org.lightcouch.DocumentConflictException;
 import org.lightcouch.ReplicationResult;
 import org.lightcouch.ReplicationResult.ReplicationHistory;
 import org.lightcouch.ReplicatorDocument;
 import org.lightcouch.Response;
+import org.lightcouch.URIBuilder;
 import org.lightcouch.ViewResult;
 
 public class ReplicationTest {


### PR DESCRIPTION
# Current behaviour
LightCouch support Local Documents with the same API than the rest of documents but these documents has some differences that could be better to manage explicitly

# Proposed change

This PR adds a explicit local management.
- Rev is not required in CouchDB 2.x for updating or deleting local docs 
- Access to the builtin view (_local_docs) in CouchDB 2.x

 ```java
        dbClient.local().save(new Foo("test"));
        List<JsonObject> list = dbClient.local().findAll();
        List<Foo> list = dbClient.local().findAll(Foo.class);
        Foo foo = dbClient.local().find(Foo.class, "test");
        foo = dbClient.local().remove("test");
```
# Reference
It is a proposal for issue #7 

