### PR TITLE
Add seq_interval parameter to changes API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # 0.2.2 (UNRELEASED)
 - [NEW] Added explicit API for local document management.
+- [NEW] Added seq_interval parameter in Changes API
 
 # 0.2.1 (21/02/2018)
 - [NEW] Added API for specifying a mango selector _changes operation

--- a/src/main/java/org/lightcouch/Changes.java
+++ b/src/main/java/org/lightcouch/Changes.java
@@ -192,6 +192,11 @@ public class Changes {
 		return this;
 	}
 	
+	public Changes seqInterval(long batchSize) {
+        uriBuilder.query("seq_interval", batchSize);
+        return this;
+    }
+	
 	// Helper
 
 	/**

--- a/src/main/java/org/lightcouch/Changes.java
+++ b/src/main/java/org/lightcouch/Changes.java
@@ -1,17 +1,14 @@
 /*
  * Copyright (C) 2011 lightcouch.org
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package org.lightcouch;
@@ -30,8 +27,10 @@ import org.lightcouch.ChangesResult.Row;
 import com.google.gson.Gson;
 
 /**
- * <p>Contains the Change Notifications API, supports <i>normal</i> and <i>continuous</i> feed Changes. 
+ * <p>
+ * Contains the Change Notifications API, supports <i>normal</i> and <i>continuous</i> feed Changes.
  * <h3>Usage Example:</h3>
+ * 
  * <pre>
  * // feed type normal 
  * String since = dbClient.context().info().getUpdateSeq(); // latest update seq
@@ -67,182 +66,186 @@ import com.google.gson.Gson;
  *	.getChanges();
  *
  * </pre>
+ * 
  * @see ChangesResult
  * @since 0.0.2
  * @author Ahmed Yehia
  */
 public class Changes {
-	
-	private BufferedReader reader;
-	private HttpUriRequest httpRequest;
-	private Row nextRow;
-	private boolean stop;
-	
-	private CouchDbClientBase dbc;
-	private Gson gson;
-	private URIBuilder uriBuilder;
-	
-	private String selector;
-	
-	Changes(CouchDbClientBase dbc) {
-		this.dbc = dbc;
-		this.gson = dbc.getGson();
-		this.uriBuilder = URIBuilder.buildUri(dbc.getDBUri()).path("_changes");
-	}
 
-	/**
-	 * Requests Change notifications of feed type continuous.
-	 * <p>Feed notifications are accessed in an <i>iterator</i> style.
-	 * @return {@link Changes}
-	 */
-	public Changes continuousChanges() {
-		final URI uri = uriBuilder.query("feed", "continuous").build();
-		if (selector == null) {
-			final HttpGet get = new HttpGet(uri);
-			httpRequest = get;
-			final InputStream in = dbc.get(get);
-			final InputStreamReader is = new InputStreamReader(in, Charsets.UTF_8);
-			setReader(new BufferedReader(is));
-		} else {
-			final HttpPost post = new HttpPost(uri);
-			httpRequest = post;
-			final InputStream in = dbc.post(post, selector);
-			final InputStreamReader is = new InputStreamReader(in, Charsets.UTF_8);
-			setReader(new BufferedReader(is));
-		}
-		return this;
-	}
+    private BufferedReader reader;
+    private HttpUriRequest httpRequest;
+    private Row nextRow;
+    private boolean stop;
 
-	/**
-	 * Checks whether a feed is available in the continuous stream, blocking 
-	 * until a feed is received. 
-	 * @return true If a feed is available
-	 */
-	public boolean hasNext() { 
-		return readNextRow();
-	}
+    private CouchDbClientBase dbc;
+    private Gson gson;
+    private URIBuilder uriBuilder;
 
-	/**
-	 * @return The next feed in the stream.
-	 */
-	public Row next() {
-		return getNextRow();
-	}
+    private String selector;
 
-	/**
-	 * Stops a running continuous feed.
-	 */
-	public void stop() {
-		stop = true;
-	}
+    Changes(CouchDbClientBase dbc) {
+        this.dbc = dbc;
+        this.gson = dbc.getGson();
+        this.uriBuilder = URIBuilder.buildUri(dbc.getDBUri()).path("_changes");
+    }
 
-	/**
-	 * Requests Change notifications of feed type normal.
-	 * @return {@link ChangesResult}
-	 */
-	public ChangesResult getChanges() {
-		final URI uri = uriBuilder.query("feed", "normal").build();
-		if (selector == null) {
-			return dbc.get(uri, ChangesResult.class);
-		} else {
-			return dbc.post(uri, selector, ChangesResult.class);
-		}
-	}
+    /**
+     * Requests Change notifications of feed type continuous.
+     * <p>
+     * Feed notifications are accessed in an <i>iterator</i> style.
+     * 
+     * @return {@link Changes}
+     */
+    public Changes continuousChanges() {
+        final URI uri = uriBuilder.query("feed", "continuous").build();
+        if (selector == null) {
+            final HttpGet get = new HttpGet(uri);
+            httpRequest = get;
+            final InputStream in = dbc.get(get);
+            final InputStreamReader is = new InputStreamReader(in, Charsets.UTF_8);
+            setReader(new BufferedReader(is));
+        } else {
+            final HttpPost post = new HttpPost(uri);
+            httpRequest = post;
+            final InputStream in = dbc.post(post, selector);
+            final InputStreamReader is = new InputStreamReader(in, Charsets.UTF_8);
+            setReader(new BufferedReader(is));
+        }
+        return this;
+    }
 
-	// Query Params
-	
-	public Changes since(String since) {
-		uriBuilder.query("since", since);
-		return this;
-	}
-	
-	public Changes limit(int limit) {
-		uriBuilder.query("limit", limit);
-		return this;
-	}
-	
-	public Changes heartBeat(long heartBeat) {
-		uriBuilder.query("heartbeat", heartBeat);
-		return this;
-	}
-	
-	public Changes timeout(long timeout) {
-		uriBuilder.query("timeout", timeout);
-		return this;
-	}
+    /**
+     * Checks whether a feed is available in the continuous stream, blocking until a feed is received.
+     * 
+     * @return true If a feed is available
+     */
+    public boolean hasNext() {
+        return readNextRow();
+    }
 
-	public Changes filter(String filter) {
-		uriBuilder.query("filter", filter);
-		return this;
-	}
-	
-	public Changes selector(String json) {
-		uriBuilder.query("filter", "_selector");
-		this.selector = json;
-		return this;
-	}
-	
-	public Changes includeDocs(boolean includeDocs) {
-		uriBuilder.query("include_docs", includeDocs);
-		return this;
-	}
-	
-	public Changes style(String style) {
-		uriBuilder.query("style", style);
-		return this;
-	}
-	
-	public Changes seqInterval(long batchSize) {
+    /**
+     * @return The next feed in the stream.
+     */
+    public Row next() {
+        return getNextRow();
+    }
+
+    /**
+     * Stops a running continuous feed.
+     */
+    public void stop() {
+        stop = true;
+    }
+
+    /**
+     * Requests Change notifications of feed type normal.
+     * 
+     * @return {@link ChangesResult}
+     */
+    public ChangesResult getChanges() {
+        final URI uri = uriBuilder.query("feed", "normal").build();
+        if (selector == null) {
+            return dbc.get(uri, ChangesResult.class);
+        } else {
+            return dbc.post(uri, selector, ChangesResult.class);
+        }
+    }
+
+    // Query Params
+
+    public Changes since(String since) {
+        uriBuilder.query("since", since);
+        return this;
+    }
+
+    public Changes limit(int limit) {
+        uriBuilder.query("limit", limit);
+        return this;
+    }
+
+    public Changes heartBeat(long heartBeat) {
+        uriBuilder.query("heartbeat", heartBeat);
+        return this;
+    }
+
+    public Changes timeout(long timeout) {
+        uriBuilder.query("timeout", timeout);
+        return this;
+    }
+
+    public Changes filter(String filter) {
+        uriBuilder.query("filter", filter);
+        return this;
+    }
+
+    public Changes selector(String json) {
+        uriBuilder.query("filter", "_selector");
+        this.selector = json;
+        return this;
+    }
+
+    public Changes includeDocs(boolean includeDocs) {
+        uriBuilder.query("include_docs", includeDocs);
+        return this;
+    }
+
+    public Changes style(String style) {
+        uriBuilder.query("style", style);
+        return this;
+    }
+
+    public Changes seqInterval(long batchSize) {
         uriBuilder.query("seq_interval", batchSize);
         return this;
     }
-	
-	// Helper
 
-	/**
-	 * Reads and sets the next feed in the stream.
-	 */
-	private boolean readNextRow() {
-		boolean hasNext = false;
-		try {
-			if(!stop) {
-				String row = ""; 
-				do {
-					row = getReader().readLine(); 
-				} while(row.length() == 0);
-				
-				if(!row.startsWith("{\"last_seq\":")) { 
-					setNextRow(gson.fromJson(row, Row.class));
-					hasNext = true;
-				} 
-			} 
-		} catch (Exception e) {
-			terminate();
-			throw new CouchDbException("Error reading continuous stream.", e);
-		} 
-		if(!hasNext) 
-			terminate();
-		return hasNext;
-	}
+    // Helper
 
-	private BufferedReader getReader() {
-		return reader;
-	}
+    /**
+     * Reads and sets the next feed in the stream.
+     */
+    private boolean readNextRow() {
+        boolean hasNext = false;
+        try {
+            if (!stop) {
+                String row = "";
+                do {
+                    row = getReader().readLine();
+                } while (row.length() == 0);
 
-	private void setReader(BufferedReader reader) {
-		this.reader = reader;
-	}
+                if (!row.startsWith("{\"last_seq\":")) {
+                    setNextRow(gson.fromJson(row, Row.class));
+                    hasNext = true;
+                }
+            }
+        } catch (Exception e) {
+            terminate();
+            throw new CouchDbException("Error reading continuous stream.", e);
+        }
+        if (!hasNext)
+            terminate();
+        return hasNext;
+    }
 
-	private Row getNextRow() {
-		return nextRow;
-	}
+    private BufferedReader getReader() {
+        return reader;
+    }
 
-	private void setNextRow(Row nextRow) {
-		this.nextRow = nextRow;
-	}
-	
-	private void terminate() {
-		httpRequest.abort();
-		CouchDbUtil.close(getReader());
-	}
+    private void setReader(BufferedReader reader) {
+        this.reader = reader;
+    }
+
+    private Row getNextRow() {
+        return nextRow;
+    }
+
+    private void setNextRow(Row nextRow) {
+        this.nextRow = nextRow;
+    }
+
+    private void terminate() {
+        httpRequest.abort();
+        CouchDbUtil.close(getReader());
+    }
 }

--- a/src/test/java/org/lightcouch/tests/ChangeNotificationsTest.java
+++ b/src/test/java/org/lightcouch/tests/ChangeNotificationsTest.java
@@ -58,6 +58,35 @@ public class ChangeNotificationsTest extends CouchDbTestBase {
 		
 		assertThat(rows.size(), is(1));
 	}
+	
+    @Test
+    public void changes_normalFeed_seqInterval() {
+        dbClient.save(new Foo());
+        dbClient.save(new Foo());
+        dbClient.save(new Foo());
+        dbClient.save(new Foo());
+        dbClient.save(new Foo());
+
+        ChangesResult changes = dbClient.changes().includeDocs(true).limit(5).seqInterval(2).getChanges();
+
+        List<ChangesResult.Row> rows = changes.getResults();
+
+        int seqs = 0;
+        for (Row row : rows) {
+            List<ChangesResult.Row.Rev> revs = row.getChanges();
+            String docId = row.getId();
+            JsonObject doc = row.getDoc();
+            if (row.getSeq() != null)
+                seqs++;
+
+            assertNotNull(revs);
+            assertNotNull(docId);
+            assertNotNull(doc);
+        }
+
+        assertThat(rows.size(), is(5));
+        assertThat(seqs, is(2));
+    }
 
 	@Test
 	public void changes_normalFeed_selector() {

--- a/src/test/java/org/lightcouch/tests/ChangeNotificationsTest.java
+++ b/src/test/java/org/lightcouch/tests/ChangeNotificationsTest.java
@@ -61,6 +61,8 @@ public class ChangeNotificationsTest extends CouchDbTestBase {
 	
     @Test
     public void changes_normalFeed_seqInterval() {
+        Assume.assumeTrue(isCouchDB2());
+
         dbClient.save(new Foo());
         dbClient.save(new Foo());
         dbClient.save(new Foo());


### PR DESCRIPTION
This parameter allows tho define the batch size of changes result for each change seq computation. This can reduce the cost of changes operation and reduce the size of the result. 

This PR fixes #5 