### PR TITLE
Add to CouchDBInfo attributes included by versions 2.x and 3.x

### DIFF
--- a/src/main/java/org/lightcouch/CouchDbInfo.java
+++ b/src/main/java/org/lightcouch/CouchDbInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 indaba.es
+ * Copyright (C) 2021 indaba.es
  * Copyright (C) 2011 lightcouch.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,71 +21,107 @@ import com.google.gson.annotations.SerializedName;
 
 /**
  * Holds information about a CouchDB database instance.
+ * 
  * @author Ahmed Yehia
  */
 public class CouchDbInfo {
-	
-	@SerializedName("db_name")
-	private String dbName;
-	@SerializedName("doc_count")
-	private long docCount;
-	@SerializedName("doc_del_count")
-	private String docDelCount;
-	@SerializedName("update_seq")
-	private String updateSeq;
-	@SerializedName("purge_seq")
-	private String purgeSeq;
-	@SerializedName("compact_running")
-	private boolean compactRunning;
-	@SerializedName("disk_size")
-	private long diskSize;
-	@SerializedName("instance_start_time")
-	private long instanceStartTime;
-	@SerializedName("disk_format_version")
-	private int diskFormatVersion;
 
-	public String getDbName() {
-		return dbName;
-	}
+  @SerializedName("db_name")
+  private String dbName;
+  @SerializedName("doc_count")
+  private long docCount;
+  @SerializedName("doc_del_count")
+  private String docDelCount;
+  @SerializedName("update_seq")
+  private String updateSeq;
+  @SerializedName("purge_seq")
+  private String purgeSeq;
+  @SerializedName("compact_running")
+  private boolean compactRunning;
+  @SerializedName("disk_size")
+  private long diskSize;
+  @SerializedName("instance_start_time")
+  private long instanceStartTime;
+  @SerializedName("disk_format_version")
+  private int diskFormatVersion;
 
-	public long getDocCount() {
-		return docCount;
-	}
+  private CouchDbInfoCluster cluster;
+  private CouchDbInfoSizes sizes;
+  private CouchDbInfoProps props;
 
-	public String getDocDelCount() {
-		return docDelCount;
-	}
+  public String getDbName() {
+    return dbName;
+  }
 
-	public String getUpdateSeq() {
-		return updateSeq;
-	}
+  public long getDocCount() {
+    return docCount;
+  }
 
-	public String getPurgeSeq() {
-		return purgeSeq;
-	}
+  public String getDocDelCount() {
+    return docDelCount;
+  }
 
-	public boolean isCompactRunning() {
-		return compactRunning;
-	}
+  public String getUpdateSeq() {
+    return updateSeq;
+  }
 
-	public long getDiskSize() {
-		return diskSize;
-	}
+  public String getPurgeSeq() {
+    return purgeSeq;
+  }
 
-	public long getInstanceStartTime() {
-		return instanceStartTime;
-	}
+  public boolean isCompactRunning() {
+    return compactRunning;
+  }
 
-	public int getDiskFormatVersion() {
-		return diskFormatVersion;
-	}
+  public long getDiskSize() {
+    return diskSize;
+  }
 
-	@Override
-	public String toString() {
-		return String
-				.format("CouchDbInfo [dbName=%s, docCount=%s, docDelCount=%s, updateSeq=%s, purgeSeq=%s, compactRunning=%s, diskSize=%s, instanceStartTime=%s, diskFormatVersion=%s]",
-						dbName, docCount, docDelCount, updateSeq, purgeSeq,
-						compactRunning, diskSize, instanceStartTime,
-						diskFormatVersion);
-	}
+  public long getInstanceStartTime() {
+    return instanceStartTime;
+  }
+
+  public int getDiskFormatVersion() {
+    return diskFormatVersion;
+  }
+
+  public CouchDbInfoCluster getCluster() {
+    return cluster;
+  }
+
+  public void setCluster(CouchDbInfoCluster cluster) {
+    this.cluster = cluster;
+  }
+
+  public CouchDbInfoSizes getSizes() {
+    return sizes;
+  }
+
+  public void setSizes(CouchDbInfoSizes sizes) {
+    this.sizes = sizes;
+  }
+
+  public CouchDbInfoProps getProps() {
+    return props;
+  }
+
+  public void setProps(CouchDbInfoProps props) {
+    this.props = props;
+  }
+  
+  @Override
+  public String toString() {
+    
+    String dbinfo = String.format(
+        "CouchDbInfo [dbName=%s, docCount=%s, docDelCount=%s, updateSeq=%s, purgeSeq=%s, compactRunning=%s, diskSize=%s, instanceStartTime=%s, diskFormatVersion=%s]",
+        dbName, docCount, docDelCount, updateSeq, purgeSeq, compactRunning, diskSize, instanceStartTime,
+        diskFormatVersion);
+      
+        if (cluster != null) dbinfo += "\n" + cluster.toString();
+        if (sizes != null) dbinfo += "\n" + sizes.toString();
+        if (props != null) dbinfo += "\n" + props.toString();
+    
+        return dbinfo;
+  }
+
 }

--- a/src/main/java/org/lightcouch/CouchDbInfoCluster.java
+++ b/src/main/java/org/lightcouch/CouchDbInfoCluster.java
@@ -1,0 +1,47 @@
+package org.lightcouch;
+
+public class CouchDbInfoCluster {
+
+  private long n;
+  private long q;
+  private long r;
+  private long w;
+
+  public long getN() {
+    return n;
+  }
+
+  public void setN(long n) {
+    this.n = n;
+  }
+
+  public long getQ() {
+    return q;
+  }
+
+  public void setQ(long q) {
+    this.q = q;
+  }
+
+  public long getR() {
+    return r;
+  }
+
+  public void setR(long r) {
+    this.r = r;
+  }
+
+  public long getW() {
+    return w;
+  }
+
+  public void setW(long w) {
+    this.w = w;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("CouchDbInfoCluster [n=%s, q=%s, r=%s, w=%s]", n, q, r, w);
+  }
+
+}

--- a/src/main/java/org/lightcouch/CouchDbInfoProps.java
+++ b/src/main/java/org/lightcouch/CouchDbInfoProps.java
@@ -1,0 +1,19 @@
+package org.lightcouch;
+
+public class CouchDbInfoProps {
+
+  private boolean partitioned;
+
+  public boolean isPartitioned() {
+    return partitioned;
+  }
+
+  public void setPartitioned(boolean partitioned) {
+    this.partitioned = partitioned;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("CouchDbInfoProps [partitioned=%s]", partitioned);
+  }
+}

--- a/src/main/java/org/lightcouch/CouchDbInfoSizes.java
+++ b/src/main/java/org/lightcouch/CouchDbInfoSizes.java
@@ -1,0 +1,38 @@
+package org.lightcouch;
+
+public class CouchDbInfoSizes {
+
+  private long active;
+  private long external;
+  private long file;
+
+  public long getActive() {
+    return active;
+  }
+
+  public void setActive(long active) {
+    this.active = active;
+  }
+
+  public long getExternal() {
+    return external;
+  }
+
+  public void setExternal(long external) {
+    this.external = external;
+  }
+
+  public long getFile() {
+    return file;
+  }
+
+  public void setFile(long file) {
+    this.file = file;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("CouchDbInfoSizes [active=%s, external=%s, file=%s]", active, external, file);
+  }
+
+}

--- a/src/test/java/org/lightcouch/tests/CouchDbTestBase.java
+++ b/src/test/java/org/lightcouch/tests/CouchDbTestBase.java
@@ -31,6 +31,10 @@ public class CouchDbTestBase {
         return isCouchDBVersion(">=2.0.0");
     }
     
+    protected boolean isCouchDB3() {
+      return isCouchDBVersion(">=3.0.0");
+  }
+    
     protected boolean isCouchDB1() {
         return isCouchDBVersion(">=0.0.0 & <2.0.0"); 
     }

--- a/src/test/java/org/lightcouch/tests/DBServerTest.java
+++ b/src/test/java/org/lightcouch/tests/DBServerTest.java
@@ -28,38 +28,45 @@ import org.lightcouch.CouchDbInfo;
 
 public class DBServerTest extends CouchDbTestBase {
 
+  @Test
+  public void dbInfo() {
+    CouchDbInfo dbInfo = dbClient.context().info();
+    assertNotNull(dbInfo);
+    if (isCouchDB2()) {
+      assertNotNull(dbInfo.getSizes());
+      assertNotNull(dbInfo.getCluster());
+    }
+    if (isCouchDB3()) {
+      assertNotNull(dbInfo.getProps());
+    }
+    System.out.println(dbInfo);
+  }
 
-	@Test
-	public void dbInfo() {
-		CouchDbInfo dbInfo = dbClient.context().info();
-		assertNotNull(dbInfo);
-	}
+  @Test
+  public void serverVersion() {
+    String version = dbClient.context().serverVersion();
+    assertNotNull(version);
+  }
 
-	@Test
-	public void serverVersion() {
-		String version = dbClient.context().serverVersion();
-		assertNotNull(version);
-	}
+  @Test
+  public void compactDb() {
+    dbClient.context().compact();
+  }
 
-	@Test
-	public void compactDb() {
-		dbClient.context().compact();
-	}
+  @Test
+  public void allDBs() {
+    List<String> allDbs = dbClient.context().getAllDbs();
+    assertThat(allDbs.size(), is(not(0)));
+  }
 
-	@Test
-	public void allDBs() {
-		List<String> allDbs = dbClient.context().getAllDbs();
-		assertThat(allDbs.size(), is(not(0)));
-	}
+  @Test
+  public void ensureFullCommit() {
+    dbClient.context().ensureFullCommit();
+  }
 
-	@Test
-	public void ensureFullCommit() {
-		dbClient.context().ensureFullCommit();
-	}
-
-	@Test
-	public void uuids() {
-		List<String> uuids = dbClient.context().uuids(10);
-		assertThat(uuids.size(), is(10));
-	}
+  @Test
+  public void uuids() {
+    List<String> uuids = dbClient.context().uuids(10);
+    assertThat(uuids.size(), is(10));
+  }
 }


### PR DESCRIPTION
This PR adds to the DB info the new attributes defined by versions 2.x and 3.x

**2.x adds** 

> cluster.n (number) – Replicas. The number of copies of every document.
> cluster.q (number) – Shards. The number of range partitions.
> cluster.r (number) – Read quorum. The number of consistent copies of a document that need to be read before a successful reply.
> cluster.w (number) – Write quorum. The number of copies of a document that need to be written before a successful reply.
> sizes.active (number) – The size of live data inside the database, in bytes.
> sizes.external (number) – The uncompressed size of database contents in bytes.
> sizes.file (number) – The size of the database file on disk in bytes. Views indexes are not included in the calculation.

**and 3.x adds** 
> props.partitioned (boolean) – (optional) If present and true, this indicates that the database is partitioned.

Now these properties can be accessed from CouchDbInfo 

This PR fixes #28 
