### PR TITLE
Add method removeAttachment to CouchDbClientBase.java

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # 0.3.1 (UNRELEASED)
 - [MAINTENANCE] Bump Gson version to 2.8.9
-- [MAINTENANCE] Test using CouchDB 3.2.2
+- [MAINTENANCE] Tested using CouchDB 3.2.2
+- [BREAK] Moved to java 8
+- [NEW] Added removeAttachment operation
 
 # 0.3.0 (29/10/2020)
 - [MAINTENANCE] Upgrade to Apache HttpClient 5.0

--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/org/lightcouch/CouchDbClientBase.java
+++ b/src/main/java/org/lightcouch/CouchDbClientBase.java
@@ -518,6 +518,22 @@ public abstract class CouchDbClientBase {
     }
 
     /**
+     * removes an attachment from an existing document given a document id and revision and the attachment name
+     *
+     * @param name The attachment name.
+     * @param docId The document id to remove the attachment from
+     * @param docRev The document revision to remove the attachment from
+     * @return {@link Response}
+     */
+    public Response removeAttachment(String name, String docId, String docRev) {
+        assertNotEmpty(name, "name");
+        assertNotEmpty(docId, "docId");
+        assertNotEmpty(docRev, "docRev");
+        final URI uri = buildUri(getDBUri()).pathEncoded(docId).path("/").path(name).query("rev", docRev).build();
+        return delete(uri);
+    }
+
+    /**
      * Invokes an Update Handler.
      *
      * <pre>

--- a/src/test/java/org/lightcouch/tests/AttachmentsTest.java
+++ b/src/test/java/org/lightcouch/tests/AttachmentsTest.java
@@ -1,23 +1,21 @@
 /*
  * Copyright (C) 2011 lightcouch.org
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package org.lightcouch.tests;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -28,92 +26,134 @@ import java.util.UUID;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 import org.lightcouch.Attachment;
+import org.lightcouch.NoDocumentException;
 import org.lightcouch.Params;
 import org.lightcouch.Response;
 
 public class AttachmentsTest extends CouchDbTestBase {
 
-	@Test
-	public void attachmentInline() {
-		Attachment attachment1 = new Attachment("VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=", "text/plain");
+    @Test
+    public void attachmentInline() {
+        Attachment attachment1 = new Attachment("VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=", "text/plain");
 
-		Attachment attachment2 = new Attachment();
-		attachment2.setData(Base64.encodeBase64String("binary string".getBytes()));
-		attachment2.setContentType("text/plain");
+        Attachment attachment2 = new Attachment();
+        attachment2.setData(Base64.encodeBase64String("binary string".getBytes()));
+        attachment2.setContentType("text/plain");
 
-		Bar bar = new Bar(); // Bar extends Document
-		bar.addAttachment("txt_1.txt", attachment1);
-		bar.addAttachment("txt_2.txt", attachment2);
+        Bar bar = new Bar(); // Bar extends Document
+        bar.addAttachment("txt_1.txt", attachment1);
+        bar.addAttachment("txt_2.txt", attachment2);
 
-		dbClient.save(bar);
-	}
+        dbClient.save(bar);
+    }
 
-	@Test
-	public void attachmentInline_getWithDocument() {
-		Attachment attachment = new Attachment("VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=", "text/plain");
-		Bar bar = new Bar();
-		bar.addAttachment("txt_1.txt", attachment);
-		
-		Response response = dbClient.save(bar);
-		
-		Bar bar2 = dbClient.find(Bar.class, response.getId(), new Params().attachments());
-		String base64Data = bar2.getAttachments().get("txt_1.txt").getData();
-		assertNotNull(base64Data);
-	}
-	
-	@Test
-	public void attachmentStandalone() throws IOException {
-		byte[] bytesToDB = "binary data".getBytes();
-		ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
-		Response response = dbClient.saveAttachment(bytesIn, "foo.txt", "text/plain");
+    @Test
+    public void attachmentInline_getWithDocument() {
+        Attachment attachment = new Attachment("VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=", "text/plain");
+        Bar bar = new Bar();
+        bar.addAttachment("txt_1.txt", attachment);
 
-		InputStream in = dbClient.find(response.getId() + "/foo.txt");
-		ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
-		int n;
-		while ((n = in.read()) != -1) {
-			bytesOut.write(n);
-		}
-		bytesOut.flush();
-		in.close();
+        Response response = dbClient.save(bar);
 
-		byte[] bytesFromDB = bytesOut.toByteArray();
+        Bar bar2 = dbClient.find(Bar.class, response.getId(), new Params().attachments());
+        String base64Data = bar2.getAttachments().get("txt_1.txt").getData();
+        assertNotNull(base64Data);
+    }
 
-		assertArrayEquals(bytesToDB, bytesFromDB);
-	}
-	
-	@Test
-	public void standaloneAttachment_newDocumentGivenId() throws IOException {
-		byte[] bytesToDB = "binary data".getBytes();
-		ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
-		
-		String docId = generateUUID();
-		
-		dbClient.saveAttachment(bytesIn, "foo.txt", "text/plain", docId, null);
-	}
-	
-	@Test
-	public void standaloneAttachment_existingDocument() throws IOException {
-		byte[] bytesToDB = "binary data".getBytes();
-		ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
-		
-		Response respSave = dbClient.save(new Foo());
-		
-		dbClient.saveAttachment(bytesIn, "foo.txt", "text/plain", respSave.getId(), respSave.getRev());
-	}
-	
-	@Test
-	public void standaloneAttachment_docIdContainSpecialChar() throws IOException {
-		byte[] bytesToDB = "binary data".getBytes();
-		ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
-		
-		Response respSave = dbClient.save(new Bar("i/" + generateUUID()));
-		
-		dbClient.saveAttachment(bytesIn, "foo.txt", "text/plain", respSave.getId(), respSave.getRev());
-	}
-	
-	// Helper
-	
-	private static String generateUUID() {
-		return UUID.randomUUID().toString().replace("-", "");
-	}
+    @Test
+    public void attachmentStandalone() throws IOException {
+        byte[] bytesToDB = "binary data".getBytes();
+        ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
+        Response response = dbClient.saveAttachment(bytesIn, "foo.txt", "text/plain");
+
+        InputStream in = dbClient.find(response.getId() + "/foo.txt");
+        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        int n;
+        while ((n = in.read()) != -1) {
+            bytesOut.write(n);
+        }
+        bytesOut.flush();
+        in.close();
+
+        byte[] bytesFromDB = bytesOut.toByteArray();
+
+        assertArrayEquals(bytesToDB, bytesFromDB);
+    }
+
+    @Test
+    public void standaloneAttachment_newDocumentGivenId() throws IOException {
+        byte[] bytesToDB = "binary data".getBytes();
+        ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
+
+        String docId = generateUUID();
+
+        dbClient.saveAttachment(bytesIn, "foo.txt", "text/plain", docId, null);
+    }
+
+    @Test
+    public void standaloneAttachment_existingDocument() throws IOException {
+        byte[] bytesToDB = "binary data".getBytes();
+        ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
+
+        Response respSave = dbClient.save(new Foo());
+
+        dbClient.saveAttachment(bytesIn, "foo.txt", "text/plain", respSave.getId(), respSave.getRev());
+    }
+
+    @Test
+    public void standaloneAttachment_docIdContainSpecialChar() throws IOException {
+        byte[] bytesToDB = "binary data".getBytes();
+        ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
+
+        Response respSave = dbClient.save(new Bar("i/" + generateUUID()));
+
+        dbClient.saveAttachment(bytesIn, "foo.txt", "text/plain", respSave.getId(), respSave.getRev());
+    }
+
+
+    @Test
+    public void standaloneAttachment_removeAttachment() throws IOException {
+
+        byte[] bytesToDB = "binary data".getBytes();
+        ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
+
+        Response respSave = dbClient.save(new Foo());
+
+        String docId = respSave.getId();
+        String rev = respSave.getRev();
+
+        assertNotNull(rev);
+        assertNotNull(docId);
+
+        Response respSaveAttachment = dbClient.saveAttachment(bytesIn, "to_delete.txt", "text/plain", docId, rev);
+
+        rev = respSaveAttachment.getRev();
+        assertNotNull(rev);
+        assertNotNull(respSaveAttachment.getId());
+
+        InputStream in = dbClient.find(docId + "/to_delete.txt");
+
+        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        int n;
+        while ((n = in.read()) != -1) {
+            bytesOut.write(n);
+        }
+        bytesOut.flush();
+        in.close();
+
+        byte[] bytesFromDB = bytesOut.toByteArray();
+        assertArrayEquals(bytesToDB, bytesFromDB);
+
+        Response respRemoveAttachment = dbClient.removeAttachment("to_delete.txt", docId, rev);
+        assertNotNull(respRemoveAttachment.getRev());
+
+        assertThrows(NoDocumentException.class, () -> dbClient.find(docId + "/to_delete.txt"));
+
+    }
+
+    // Helper
+
+    private static String generateUUID() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
 }


### PR DESCRIPTION
Following the proposal from @holgerengels a new method removeAttachment has ben added to CouchDblientBase
The corresponding test is included in AttachmentsTest

After this PR the Java version is shifted to java 8